### PR TITLE
Nifi 9666 merge configuration

### DIFF
--- a/c2/c2-client-bundle/README.md
+++ b/c2/c2-client-bundle/README.md
@@ -15,9 +15,9 @@
 ## Apache NiFi MiNiFi Command and Control (C2) Client
 The c2-client-bundle provides implementation for the client aspect of the [C2 Protocol](https://cwiki.apache.org/confluence/display/MINIFI/C2+Design). The essence of the implementation is the heartbeat construction and the communication with the [C2 server](../../../../minifi-c2/README.md) via the C2HttpClient.
 
-Relying on the [C2 Protocol API](../c2-protocol) functionality right now is limited to sending heartbeats and processing/acknowledging UPDATE configuration operation in the response (if any). Whem exposed the new configuration will be downloaded and passed back to the system using the C2 protocol.
+Currently, relying on the [C2 Protocol API](../c2-protocol) is limited to sending heartbeats and processing/acknowledging UPDATE configuration operation in the response (if any). When exposed the new configuration will be downloaded and passed back to the system using the C2 protocol.
 
-C2ClientService needs to be scheduled to send heartbeats periodically, so the C2 Server can notify the client about any operations that is defined by the protocol and needs to be executed on the client side.
+When C2 is enabled, C2ClientService will be scheduled to send heartbeats periodically, so the C2 Server can notify the client about any operations that is defined by the protocol and needs to be executed on the client side.
 
 Using the client means that configuration changes and other operations can be triggered and controlled centrally via the C2 server making the management of clients more simple and configuring them more flexible. The client supports bidirectional TLS authentication.
 

--- a/c2/c2-client-bundle/README.md
+++ b/c2/c2-client-bundle/README.md
@@ -22,7 +22,7 @@ When C2 is enabled, C2ClientService will be scheduled to send heartbeats periodi
 Using the client means that configuration changes and other operations can be triggered and controlled centrally via the C2 server making the management of clients more simple and configuring them more flexible. The client supports bidirectional TLS authentication.
 
 ### Configuration
-To use the client the parameters coming from `C2ClientConfig` needs to be properly set (this configuration class is also used for instantiating `C2HeartbeatFactory` and `C2HttpClient`)
+To use the client, the parameters coming from `C2ClientConfig` need to be properly set (this configuration class is also used for instantiating `C2HeartbeatFactory` and `C2HttpClient`)
 
 ```
     # The C2 Server endpoint where the heartbeat is sent

--- a/c2/c2-client-bundle/README.md
+++ b/c2/c2-client-bundle/README.md
@@ -1,0 +1,61 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+## Apache NiFi MiNiFi Command and Control (C2) Client
+The c2-client-bundle provides implementation for the client aspect of the [C2 Protocol](https://cwiki.apache.org/confluence/display/MINIFI/C2+Design). The essence of the implementation is the heartbeat construction and the communication with the [C2 server](../../../../minifi-c2/README.md) via the C2HttpClient.
+
+Relying on the [C2 Protocol API](../c2-protocol) functionality right now is limited to sending heartbeats and processing/acknowledging UPDATE configuration operation in the response (if any). Whem exposed the new configuration will be downloaded and passed back to the system using the C2 protocol.
+
+C2ClientService needs to be scheduled to send heartbeats periodically, so the C2 Server can notify the client about any operations that is defined by the protocol and needs to be executed on the client side.
+
+Using the client means that configuration changes and other operations can be triggered and controlled centrally via the C2 server making the management of clients more simple and configuring them more flexible. The client supports bidirectional TLS authentication.
+
+### Configuration
+To use the client the parameters coming from `C2ClientConfig` needs to be properly set (this configuration class is also used for instantiating `C2HeartbeatFactory` and `C2HttpClient`)
+
+```
+    # The C2 Server endpoint where the heartbeat is sent
+    private final String c2Url;
+    
+    # The C2 Server endpoint where the acknowledge is sent
+    private final String c2AckUrl;
+    
+    # The class the agent belongs to (flow definition is tied to agent class on the server side)
+    private final String agentClass;
+    
+    # Unique identifier for the agent if not provided it will be generated
+    private final String agentIdentifier;
+    
+    # Directory where persistent configuration (e.g.: generated agent and device id will be persisted)
+    private final String confDirectory;
+    
+    # Property of RuntimeManifest defined in c2-protocol. A unique identifier for the manifest
+    private final String runtimeManifestIdentifier;
+    
+    # Property of RuntimeManifest defined in c2-protocol. The type of the runtime binary. Usually set when the runtime is built
+    private final String runtimeType;
+    
+    # The frequency of sending the heartbeats. This property is used by the c2-client-bundle user who should schedule the client
+    private final Long heartbeatPeriod;
+    
+    # Security properties for communication with the C2 Server
+    private final String keystoreFilename;
+    private final String keystorePass;
+    private final String keyPass;
+    private final KeystoreType keystoreType;
+    private final String truststoreFilename;
+    private final String truststorePass;
+    private final KeystoreType truststoreType;
+    private final HostnameVerifier hostnameVerifier;
+```

--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/PullHttpChangeIngestor.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/configuration/ingestors/PullHttpChangeIngestor.java
@@ -78,7 +78,7 @@ public class PullHttpChangeIngestor extends AbstractPullChangeIngestor {
     private static final String DEFAULT_CONNECT_TIMEOUT_MS = "5000";
     private static final String DEFAULT_READ_TIMEOUT_MS = "15000";
 
-    private static final String PULL_HTTP_BASE_KEY = NOTIFIER_INGESTORS_KEY + ".pull.http";
+    public static final String PULL_HTTP_BASE_KEY = NOTIFIER_INGESTORS_KEY + ".pull.http";
     public static final String PULL_HTTP_POLLING_PERIOD_KEY = PULL_HTTP_BASE_KEY + ".period.ms";
     public static final String PORT_KEY = PULL_HTTP_BASE_KEY + ".port";
     public static final String HOST_KEY = PULL_HTTP_BASE_KEY + ".hostname";

--- a/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/service/MiNiFiConfigurationChangeListener.java
+++ b/minifi/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/service/MiNiFiConfigurationChangeListener.java
@@ -27,7 +27,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -149,20 +148,6 @@ public class MiNiFiConfigurationChangeListener implements ConfigurationChangeLis
         return "MiNiFiConfigurationChangeListener";
     }
 
-    private void saveFile(InputStream configInputStream, File configFile) throws IOException {
-        try {
-            try (FileOutputStream configFileOutputStream = new FileOutputStream(configFile)) {
-                byte[] copyArray = new byte[1024];
-                int available;
-                while ((available = configInputStream.read(copyArray)) > 0) {
-                    configFileOutputStream.write(copyArray, 0, available);
-                }
-            }
-        } catch (IOException ioe) {
-            throw new IOException("Unable to save updated configuration to the configured config file location", ioe);
-        }
-    }
-
     private void restartInstance() throws IOException {
         try {
             runner.reload();
@@ -183,19 +168,19 @@ public class MiNiFiConfigurationChangeListener implements ConfigurationChangeLis
             configSchemaNew.setNifiPropertiesOverrides(configSchemaOld.getNifiPropertiesOverrides());
 
             if (!overrideCoreProperties(bootstrapProperties)) {
-                logger.info("Preserving previous core properties...");
+                logger.debug("Preserving previous core properties...");
                 configSchemaNew.setCoreProperties(configSchemaOld.getCoreProperties());
             }
 
             if (!overrideSecurityProperties(bootstrapProperties)) {
-                logger.info("Preserving previous security properties...");
+                logger.debug("Preserving previous security properties...");
                 configSchemaNew.setSecurityProperties(configSchemaOld.getSecurityProperties());
             }
 
-            logger.info("Persisting changes to {}", configFile.getAbsolutePath());
+            logger.debug("Persisting changes to {}", configFile.getAbsolutePath());
             SchemaLoader.toYaml(configSchemaNew, new FileWriter(configFile));
         } catch (Exception e) {
-            logger.info("Loading the old and the new schema for merging was not successful");
+            logger.error("Loading the old and the new schema for merging was not successful");
         }
     }
 

--- a/minifi/minifi-commons/minifi-commons-schema/src/main/java/org/apache/nifi/minifi/commons/schema/serialization/SchemaLoader.java
+++ b/minifi/minifi-commons/minifi-commons-schema/src/main/java/org/apache/nifi/minifi/commons/schema/serialization/SchemaLoader.java
@@ -17,12 +17,14 @@
 
 package org.apache.nifi.minifi.commons.schema.serialization;
 
+import java.io.Writer;
 import org.apache.nifi.minifi.commons.schema.ConfigSchema;
 import org.apache.nifi.minifi.commons.schema.common.ConvertableSchema;
 import org.apache.nifi.minifi.commons.schema.common.StringUtil;
 import org.apache.nifi.minifi.commons.schema.exception.SchemaLoaderException;
 import org.apache.nifi.minifi.commons.schema.v1.ConfigSchemaV1;
 import org.apache.nifi.minifi.commons.schema.v2.ConfigSchemaV2;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.error.YAMLException;
 
@@ -65,6 +67,15 @@ public class SchemaLoader {
         } finally {
             sourceStream.close();
         }
+    }
+
+    public static void toYaml(ConfigSchema schema, Writer writer) {
+        final DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+
+        Yaml yaml = new Yaml(options);
+        yaml.dump(schema.toMap(), writer);
     }
 
     public static ConfigSchema loadConfigSchemaFromYaml(InputStream sourceStream) throws IOException, SchemaLoaderException {

--- a/minifi/minifi-docs/src/main/markdown/minifi-java-agent-quick-start.md
+++ b/minifi/minifi-docs/src/main/markdown/minifi-java-agent-quick-start.md
@@ -87,12 +87,12 @@ For Windows users, navigate to the folder where MiNiFi was installed. Navigate t
 
 This launches MiNiFi and leaves it running in the foreground. To shut down NiFi, select the window that was launched and hold the Ctrl key while pressing C.
 
-# Working with dataflows
+# Working with DataFlows
 When you are working with a MiNiFi dataflow, you should design it, add any additional configuration your environment or use case requires, and then deploy your dataflow. MiNiFi is not designed to accommodate substantial mid-dataflow configuration.
 
-## Setting up Your Dataflow
+## Setting up Your DataFlow
 
-### Manually from a NiFi dataflow
+### Manually from a NiFi Dataflow
 You can use the MiNiFi Toolkit, located in your MiNiFi installation directory, and any NiFi instance to set up the dataflow you want MiNiFi to run:
 
 1. Launch NiFi
@@ -111,7 +111,7 @@ config.sh transform input_file output_file
 **Result:** Once you have your _config.yml_ file in the `minifi/conf` directory, launch that instance of MiNiFi and your dataflow begins automatically.
 
 ### Utilizing a C2 Server via the c2 protocol
-If you have a [C2 server](../../../../minifi-c2/README.md) running you can expose the whole config.yml for the agent to download. As the agent is heartbeating via the C2 protocol changes in flow version will trigger automatic config updates.
+If you have a [C2 server](../../../../minifi-c2/README.md) running, you can expose the whole _config.yml_ for the agent to download. As the agent is heartbeating via the C2 protocol, changes in flow version will trigger automatic config updates.
 
 1. Launch C2 server
 2. Configure MiNiFi for C2 capability
@@ -126,21 +126,21 @@ c2.agent.heartbeat.period=5000
 #(Optional) c2.agent.identifier=123-456-789
 c2.agent.class=agentClassName
 ```
-3. Configure MiNiFi to recognise config.yml changes
+3. Configure MiNiFi to recognize _config.yml_ changes
 ```
 nifi.minifi.notifier.ingestors=org.apache.nifi.minifi.bootstrap.configuration.ingestors.FileChangeIngestor
 nifi.minifi.notifier.ingestors.file.config.path=./conf/config-new.yml
 nifi.minifi.notifier.ingestors.file.polling.period.seconds=5
 ```
 4. Start MiNiFi
-5. When a new flow is available on the C2 server MiNiFi will download it via C2 and restart itself to pick up the changes
+5. When a new flow is available on the C2 server, MiNiFi will download it via C2 and restart itself to pick up the changes
 
-**Note:** Flow definitions are class based. Each class has one flow defined for it. So all the agents belonging to the same class will get the flow at update.
+**Note:** Flow definitions are class based. Each class has one flow defined for it. As a result, all the agents belonging to the same class will get the flow at update.
 
 ## Loading a New Dataflow
 
 ### Manually
-You can load a new dataflow for a MiNiFi instance to run:
+To load a new dataflow for a MiNiFi instance to run:
 
 1. Create a new _config.yml_ file with the new dataflow.
 2. Replace the existing _config.yml_ in `minifi/conf` with the new file.
@@ -148,10 +148,10 @@ You can load a new dataflow for a MiNiFi instance to run:
 
 ### Utilizing C2 protocol
 1. Change the flow definition on the C2 Server
-2. When a new flow is available on the C2 server MiNiFi will download it via C2 and restart itself to pick up the changes
+2. When a new flow is available on the C2 server, MiNiFi will download it via C2 and restart itself to pick up the changes
 
 ## Using Processors Not Packaged with MiNiFi
-MiNiFi is able to use following processors out of the box:
+MiNiFi is able to use the following processors out of the box:
 * UpdateAttribute
 * AttributesToJSON
 * Base64EncodeContent

--- a/minifi/minifi-docs/src/main/markdown/minifi-java-agent-quick-start.md
+++ b/minifi/minifi-docs/src/main/markdown/minifi-java-agent-quick-start.md
@@ -123,7 +123,7 @@ c2.runtime.type=minifi-java
 c2.rest.url=http://localhost:10090/c2/config/heartbeat
 c2.rest.url.ack=http://localhost:10090/c2/config/acknowledge
 c2.agent.heartbeat.period=5000
-#c2.agent.identifier=123-456-789 // Optional
+#(Optional) c2.agent.identifier=123-456-789
 c2.agent.class=agentClassName
 ```
 3. Configure MiNiFi to recognise config.yml changes

--- a/minifi/minifi-docs/src/main/markdown/minifi-java-agent-quick-start.md
+++ b/minifi/minifi-docs/src/main/markdown/minifi-java-agent-quick-start.md
@@ -91,6 +91,8 @@ This launches MiNiFi and leaves it running in the foreground. To shut down NiFi,
 When you are working with a MiNiFi dataflow, you should design it, add any additional configuration your environment or use case requires, and then deploy your dataflow. MiNiFi is not designed to accommodate substantial mid-dataflow configuration.
 
 ## Setting up Your Dataflow
+
+### Manually from a NiFi dataflow
 You can use the MiNiFi Toolkit, located in your MiNiFi installation directory, and any NiFi instance to set up the dataflow you want MiNiFi to run:
 
 1. Launch NiFi
@@ -106,8 +108,47 @@ config.sh transform input_file output_file
 
 **Note:** You can use one template at a time, per MiNiFi instance.
 
-
 **Result:** Once you have your _config.yml_ file in the `minifi/conf` directory, launch that instance of MiNiFi and your dataflow begins automatically.
+
+### Utilizing a C2 Server via the c2 protocol
+If you have a [C2 server](../../../../minifi-c2/README.md) running you can expose the whole config.yml for the agent to download. As the agent is heartbeating via the C2 protocol changes in flow version will trigger automatic config updates.
+
+1. Launch C2 server
+2. Configure MiNiFi for C2 capability
+```
+c2.enable=true
+c2.config.directory=./conf
+c2.runtime.manifest.identifier=minifi
+c2.runtime.type=minifi-java
+c2.rest.url=http://localhost:10090/c2/config/heartbeat
+c2.rest.url.ack=http://localhost:10090/c2/config/acknowledge
+c2.agent.heartbeat.period=5000
+#c2.agent.identifier=123-456-789 // Optional
+c2.agent.class=agentClassName
+```
+3. Configure MiNiFi to recognise config.yml changes
+```
+nifi.minifi.notifier.ingestors=org.apache.nifi.minifi.bootstrap.configuration.ingestors.FileChangeIngestor
+nifi.minifi.notifier.ingestors.file.config.path=./conf/config-new.yml
+nifi.minifi.notifier.ingestors.file.polling.period.seconds=5
+```
+4. Start MiNiFi
+5. When a new flow is available on the C2 server MiNiFi will download it via C2 and restart itself to pick up the changes
+
+**Note:** Flow definitions are class based. Each class has one flow defined for it. So all the agents belonging to the same class will get the flow at update.
+
+## Loading a New Dataflow
+
+### Manually
+You can load a new dataflow for a MiNiFi instance to run:
+
+1. Create a new _config.yml_ file with the new dataflow.
+2. Replace the existing _config.yml_ in `minifi/conf` with the new file.
+3. Restart MiNiFi.
+
+### Utilizing C2 protocol
+1. Change the flow definition on the C2 Server
+2. When a new flow is available on the C2 server MiNiFi will download it via C2 and restart itself to pick up the changes
 
 ## Using Processors Not Packaged with MiNiFi
 MiNiFi is able to use following processors out of the box:
@@ -271,13 +312,6 @@ minifi.sh flowStatus processor:TailFile:health,stats,bulletins
 **Note:** Any connections, remote process groups or processors names that contain ":", ";" or "," will cause parsing errors when querying.
 
 For details on the `flowStatus` option, see the "FlowStatus Query Option" section of the [Administration Guide](https://nifi.apache.org/minifi/system-admin-guide.html).
-
-## Loading a New Dataflow
-You can load a new dataflow for a MiNiFi instance to run:
-
-1. Create a new _config.yml_ file with the new dataflow.
-2. Replace the existing _config.yml_ in `minifi/conf` with the new file.
-3. Restart MiNiFi.
 
 ## Stopping MiNiFi
 


### PR DESCRIPTION
Added logic to reach feature parity with the old minifi java approach.
So now we will preserve the following sections of the old config.yml when updating configuration:
- Core properties
- Security properties
- NiFi properties override

(security properties in bootstrap.conf will still take precedence over everything if confuigured)

I will close the [README update PR](https://github.com/mattyb149/nifi/pull/23) because I branched my current changes form that so this PR includes that and the required changes too.